### PR TITLE
bump open telemetry

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   def project do
     [
       app: :opentelemetry_absinthe,
-      version: "1.0.0-rc.2",
+      version: "1.0.0",
       elixir: "~> 1.10",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
Some deps have been updated to support opentelemetry_api 1.0.0-rc.2 and opentelemetry 1.0.0-rc.2.

Since this could be a breaking change for those who use opentelemetry_absinthe currenty, I bumped the version to 1.0.0-rc.2.