### PR TITLE
Use fully qualified names for anonymous functions

### DIFF
--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -36,14 +36,14 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     :telemetry.attach(
       {__MODULE__, :operation_start},
       [:absinthe, :execute, :operation, :start],
-      &handle_operation_start/4,
+      &__MODULE__.handle_operation_start/4,
       config
     )
 
     :telemetry.attach(
       {__MODULE__, :operation_stop},
       [:absinthe, :execute, :operation, :stop],
-      &handle_operation_stop/4,
+      &__MODULE__.handle_operation_stop/4,
       config
     )
   end


### PR DESCRIPTION
Used __MODULE__ as suggested by telemetry itself
