### PR TITLE
Add tracing support for root-level selections + tests

### DIFF
--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -77,10 +77,8 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
       case data do
         %{blueprint: %{operations: [_ | _] = operations}} ->
           operations
-          |> Enum.reduce([], fn selections, list ->
-            selections.selections
-            |> Enum.reduce(list, fn selection, list -> [selection.name | list] end)
-          end)
+          |> Enum.flat_map(& &1.selections)
+          |> Enum.map(& &1.name)
           |> Enum.uniq()
 
         _ ->

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -74,12 +74,18 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
 
   def handle_operation_stop(_event_name, _measurements, data, config) do
     fields =
-      data.blueprint.operations
-      |> Enum.reduce([], fn selections, list ->
-        selections.selections
-        |> Enum.reduce(list, fn selection, list -> [selection.name | list] end)
-      end)
-      |> Enum.uniq()
+      case data do
+        %{blueprint: %{operations: [_ | _] = operations}} ->
+          operations
+          |> Enum.reduce([], fn selections, list ->
+            selections.selections
+            |> Enum.reduce(list, fn selection, list -> [selection.name | list] end)
+          end)
+          |> Enum.uniq()
+
+        _ ->
+          []
+      end
 
     errors = data.blueprint.result[:errors]
 

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -87,8 +87,6 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
       {:ok, _} = Absinthe.run(@query, Schema, variables: %{"isbn" => "A1"})
       assert_receive {:span, span(attributes: {_, _, _, _, attributes})}, 5000
 
-      IO.inspect(attributes)
-
       assert ["book"] = attributes["graphql.request.selections"] |> Jason.decode!()
     end
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -34,6 +34,8 @@ defmodule AbsinthePlug.Test.Schema do
         {:ok, get_book_by_isbn(args.isbn)}
       end)
     end
+
+    field :books, list_of(:book)
   end
 end
 


### PR DESCRIPTION
This PR adds the ability to trace the specific root-level query/mutation fields that were requested in a particular query. This allows APM tools and other OTEL consumers to search by specific GQL fields (e.g. the specific query being called), which is not currently possible