### PR TITLE
Allow additional attributes in spans

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -3,3 +3,6 @@ import Config
 config :opentelemetry,
   tracer: :otel_tracer_default,
   processors: [{:otel_batch_processor, %{scheduled_delay_ms: 1}}]
+
+# Print only errors during tests
+config :logger, :console, level: :error

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -23,7 +23,8 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     trace_request_query: true,
     trace_request_variables: true,
     trace_response_result: true,
-    trace_response_errors: true
+    trace_response_errors: true,
+    additional_attributes: []
   ]
 
   def setup(instrumentation_opts \\ []) do
@@ -57,7 +58,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     params = metadata |> Map.get(:options, []) |> Keyword.get(:params, %{})
 
     attributes =
-      []
+      config.additional_attributes
       |> put_if(
         config.trace_request_variables,
         {"graphql.request.variables", Jason.encode!(params["variables"])}

--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -4,4 +4,5 @@ defmodule OpentelemetryAbsinthe do
   """
 
   defdelegate setup, to: OpentelemetryAbsinthe.Instrumentation
+  defdelegate setup(opts), to: OpentelemetryAbsinthe.Instrumentation
 end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
       {:absinthe, ">= 1.5.0", optional: true},
       {:jason, "~> 1.2"},
       {:opentelemetry_api, "~> 1.1"},
-      {:telemetry, "~> 0.4 or ~> 1.0.0"}
+      {:telemetry, "~> 0.4 or ~> 1.0"}
     ] ++ dev_deps()
   end
 

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -73,6 +73,24 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
                "graphql.response.errors"
              ] = attributes |> keys() |> Enum.sort()
     end
+
+    test "additional attributes are included in spans" do
+      additional_attributes = [env: "test"]
+      OpentelemetryAbsinthe.Instrumentation.setup(additional_attributes: additional_attributes)
+
+      {:ok, _} = Absinthe.run(@query, Schema, variables: %{"isbn" => "A1"})
+      assert_receive {:span, span(attributes: attributes)}, 5000
+
+      assert [
+               :env,
+               "graphql.request.query",
+               "graphql.request.variables",
+               "graphql.response.errors",
+               "graphql.response.result"
+             ] = attributes |> keys() |> Enum.sort()
+
+      assert elem(attributes, 4)[:env] == "test"
+    end
   end
 
   defp keys(attributes_record), do: attributes_record |> elem(4) |> Map.keys()


### PR DESCRIPTION
This PR adds several little things:
1. Allow additional attributes in spans, this could be useful to add from which environment a span comes from for example
2. Relax telemetry version so higher versions can be installed (I don't know if this could cause some problems)
3. Configure console logger level to `:error`, the test don't capture logs and I think it looks cleaner this way