### PR TITLE
Make selections lazy & prepare for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2023-02-24
+
+### Added
+
+- new `trace_request_selections` option to enable tracing root level GraphQL selections, which will be stored under `graphql.request.selections`
+
 ## [1.1.0] - 2022-09-21
 
 ### Changed
 
-* opentelemetry_absinthe does not set opentelemetry-related Logger metadata anymore, because
+- opentelemetry_absinthe does not set opentelemetry-related Logger metadata anymore, because
   The OpenTelemetry API/SDK itself [does that automatically since 1.1.0](https://github.com/open-telemetry/opentelemetry-erlang/pull/394).
   If you're upgrading to opentelemetry_absinthe 1.1.0, it is therefore recommended to also upgrade to OpenTelemetry API 1.1.0
   in order to keep the opentelemetry log metadata.
 
-[Unreleased]: https://github.com/primait/opentelemetry_absinthe/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/primait/opentelemetry_absinthe/compare/1.2.0...HEAD
+[1.2.0]: https://github.com/primait/opentelemetry_absinthe/compare/1.1.0...1.2.0
 [1.1.0]: https://github.com/primait/opentelemetry_absinthe/releases/tag/1.1.0

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -85,7 +85,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
         config.trace_response_errors,
         {"graphql.response.errors", Jason.encode!(errors)}
       )
-      |> lazy_put_if(
+      |> put_if(
         config.trace_request_selections,
         fn -> {"graphql.request.selections", data |> get_graphql_selections() |> Jason.encode!()} end
       )
@@ -117,10 +117,8 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   # This snippet is approved by José himself:
   # https://elixirforum.com/t/creating-list-adding-elements-on-specific-conditions/6295/4?u=learts
   defp put_if(list, false, _), do: list
+  defp put_if(list, true, value_fn) when is_function(value_fn), do: [value_fn.() | list]
   defp put_if(list, true, value), do: [value | list]
-
-  defp lazy_put_if(list, false, _), do: list
-  defp lazy_put_if(list, true, value_fn), do: [value_fn.() | list]
 
   # taken from https://github.com/opentelemetry-beam/opentelemetry_plug/blob/82206fb09fbeb9ffa2f167a5f58ea943c117c003/lib/opentelemetry_plug.ex#L186
   @ctx_key {__MODULE__, :parent_ctx}

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -100,7 +100,7 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
       {:ok, _} = Absinthe.run(@query, Schema, variables: %{"isbn" => "A1"})
       assert_receive {:span, span(attributes: {_, _, _, _, attributes})}, 5000
 
-      selections = attributes["graphql.request.selections"] |> Jason.decode!()
+      selections = Jason.decode!(attributes["graphql.request.selections"])
 
       refute Enum.member?(selections, "books")
 
@@ -118,7 +118,7 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
       {:ok, _} = Absinthe.run(@aliased_query, Schema, variables: %{"isbn" => "A1"})
       assert_receive {:span, span(attributes: {_, _, _, _, attributes})}, 5000
 
-      selections = attributes["graphql.request.selections"] |> Jason.decode!()
+      selections = Jason.decode!(attributes["graphql.request.selections"])
 
       assert ["book"] = selections
     end


### PR DESCRIPTION
This PR

- fixes some credo warnings
- updates the CHANGELOG
- makes the selections extraction lazy, if someone doesn't want to use it they'd still have to pay for cycling through selections