### PR TITLE
Fix docs generation

### DIFF
--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -1,6 +1,8 @@
 defmodule OpentelemetryAbsinthe do
   alias OpentelemetryAbsinthe.Instrumentation
 
+  @config Instrumentation.default_config()
+
   # Allow alias before moduledoc
   # credo:disable-for-next-line
   @moduledoc """
@@ -29,15 +31,15 @@ defmodule OpentelemetryAbsinthe do
 
   ## Configuration options
     
-    * `span_name`(default: #{Instrumentation.default_config()[:span_name]}): the name of the span attributes will be attached to
-    * `trace_request_query`(default: #{Instrumentation.default_config()[:trace_request_query]}): attaches the graphql query as an attribute
+    * `span_name`(default: #{Keyword.fetch!(@config, :span_name)}): the name of the span attributes will be attached to
+    * `trace_request_query`(default: #{Keyword.fetch!(@config, :trace_request_query)}): attaches the graphql query as an attribute
 
       **Important Note**: This is usually safe, since graphql queries are expected to be static. All dynamic data should be passed via graphql variables. 
       However some libraries(for example [dillonkearns/elm-graphql](https://github.com/dillonkearns/elm-graphql/issues/27) store the variables inline as a part of the query.
       If you expect clients to send dynamic data as a part of the graphql query you should disable this.
 
-    * `trace_request_variables`(default: #{Instrumentation.default_config()[:trace_request_variables]}): attaches the graphql variables as an attribute
-    * `trace_request_selections`(default: #{Instrumentation.default_config()[:trace_request_selections]}): attaches the root fields queried as an attribute.
+    * `trace_request_variables`(default: #{Keyword.fetch!(@config, :trace_request_variables)}): attaches the graphql variables as an attribute
+    * `trace_request_selections`(default: #{Keyword.fetch!(@config, :trace_request_selections)}): attaches the root fields queried as an attribute.
     
       For example given a query like:
       ```
@@ -57,8 +59,8 @@ defmodule OpentelemetryAbsinthe do
       will result in a graphql.request.selections attribute with the value `["book", "reader"]` being attached.
       Note that aliased fields will use their unaliased name.
 
-    * `trace_response_result`(default: #{Instrumentation.default_config()[:trace_request_result]}): attaches the result returned by the server as an attribute
-    * `trace_response_errors`(default: #{Instrumentation.default_config()[:trace_response_errors]}): attaches the errors returned by the server as an attribute
+    * `trace_response_result`(default: #{Keyword.fetch!(@config, :trace_response_result)}): attaches the result returned by the server as an attribute
+    * `trace_response_errors`(default: #{Keyword.fetch!(@config, :trace_response_errors)}): attaches the errors returned by the server as an attribute
   """
 
   defdelegate setup(instrumentation_opts \\ []), to: Instrumentation


### PR DESCRIPTION
Instead of `trace_response_result` the docs used `trace_request_result`. 
Also changed bracket key access into a Keyword.fetch! to cause an error if a similar mistake happens again