### PR TITLE
[PLATFORM-996]: Use atoms instead of strings for otel attributes

### DIFF
--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -22,9 +22,9 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   Record.defrecord(:span_ctx, @span_ctx_fields)
 
   @default_operation_span "GraphQL Operation"
-  @graphql_document_attr Atom.to_string(Conventions.graphql_document())
-  @graphql_operation_name_attr Atom.to_string(Conventions.graphql_operation_name())
-  @graphql_operation_type_attr Atom.to_string(Conventions.graphql_operation_type())
+  @graphql_document Conventions.graphql_document()
+  @graphql_operation_name Conventions.graphql_operation_name()
+  @graphql_operation_type Conventions.graphql_operation_type()
 
   @default_config [
     span_name: :dynamic,
@@ -76,9 +76,9 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
       []
       |> put_if(
         config.trace_request_variables,
-        {"graphql.request.variables", Jason.encode!(variables)}
+        {:"graphql.request.variables", Jason.encode!(variables)}
       )
-      |> put_if(config.trace_request_query, {@graphql_document_attr, document})
+      |> put_if(config.trace_request_query, {@graphql_document, document})
 
     save_parent_ctx()
 
@@ -101,23 +101,23 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
       []
       |> put_if(
         config.trace_request_type,
-        {@graphql_operation_type_attr, operation_type}
+        {@graphql_operation_type, operation_type}
       )
       |> put_if(
         config.trace_request_name,
-        {@graphql_operation_name_attr, operation_name}
+        {@graphql_operation_name, operation_name}
       )
       |> put_if(
         config.trace_response_result,
-        {"graphql.response.result", Jason.encode!(data.blueprint.result)}
+        {:"graphql.response.result", Jason.encode!(data.blueprint.result)}
       )
       |> put_if(
         config.trace_response_errors,
-        {"graphql.response.errors", Jason.encode!(errors)}
+        {:"graphql.response.errors", Jason.encode!(errors)}
       )
       |> put_if(
         config.trace_request_selections,
-        fn -> {"graphql.request.selections", data |> get_graphql_selections() |> Jason.encode!()} end
+        fn -> {:"graphql.request.selections", data |> get_graphql_selections() |> Jason.encode!()} end
       )
 
     set_status(errors)

--- a/test/configuration_test.exs
+++ b/test/configuration_test.exs
@@ -4,6 +4,11 @@ defmodule OpentelemetryAbsintheTest.Configuration do
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
+  @graphql_document :"graphql.document"
+  @graphql_operation_name :"graphql.operation.name"
+  @graphql_operation_type :"graphql.operation.type"
+  @graphql_request_selections :"graphql.request.selections"
+
   doctest OpentelemetryAbsinthe.Instrumentation
 
   describe "trace configuration" do
@@ -13,10 +18,10 @@ defmodule OpentelemetryAbsintheTest.Configuration do
       attributes = Query.query_for_attrs(Queries.query(), variables: %{"isbn" => "A1"})
 
       assert [
-               "graphql.document",
-               "graphql.operation.name",
-               "graphql.operation.type",
-               "graphql.request.selections"
+               @graphql_document,
+               @graphql_operation_name,
+               @graphql_operation_type,
+               @graphql_request_selections
              ] = attributes |> Map.keys() |> Enum.sort()
     end
 
@@ -30,10 +35,10 @@ defmodule OpentelemetryAbsintheTest.Configuration do
       attributes = Query.query_for_attrs(Queries.query(), variables: %{"isbn" => "A1"})
 
       assert [
-               "graphql.operation.name",
-               "graphql.operation.type",
-               "graphql.request.selections",
-               "graphql.response.result"
+               @graphql_operation_name,
+               @graphql_operation_type,
+               @graphql_request_selections,
+               :"graphql.response.result"
              ] = attributes |> Map.keys() |> Enum.sort()
     end
 
@@ -47,9 +52,9 @@ defmodule OpentelemetryAbsintheTest.Configuration do
       attributes = Query.query_for_attrs(Queries.query(), variables: %{"isbn" => "A1"})
 
       assert [
-               "graphql.document",
-               "graphql.operation.name",
-               "graphql.operation.type"
+               @graphql_document,
+               @graphql_operation_name,
+               @graphql_operation_type
              ] = attributes |> Map.keys() |> Enum.sort()
     end
   end

--- a/test/extraction_test.exs
+++ b/test/extraction_test.exs
@@ -4,12 +4,14 @@ defmodule OpentelemetryAbsintheTest.Extraction do
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
+  @graphql_request_selections :"graphql.request.selections"
+
   describe "extracts" do
     test "request query" do
       OpentelemetryAbsinthe.Instrumentation.setup(trace_request_query: true)
       query = Queries.query()
 
-      assert ^query = query |> Query.query_for_attrs() |> Map.fetch!("graphql.document")
+      assert ^query = query |> Query.query_for_attrs() |> Map.fetch!(:"graphql.document")
     end
 
     test "request variables" do
@@ -19,7 +21,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       assert ^variables =
                Queries.query()
                |> Query.query_for_attrs(variables: variables)
-               |> Map.fetch!("graphql.request.variables")
+               |> Map.fetch!(:"graphql.request.variables")
                |> Jason.decode!()
     end
 
@@ -29,7 +31,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       assert ["book"] =
                Queries.query()
                |> Query.query_for_attrs(variables: %{"isbn" => "A1"})
-               |> Map.fetch!("graphql.request.selections")
+               |> Map.fetch!(@graphql_request_selections)
                |> Jason.decode!()
     end
 
@@ -39,7 +41,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       assert ["create_book"] =
                Queries.mutation()
                |> Query.query_for_attrs(variables: %{"isbn" => "A1"})
-               |> Map.fetch!("graphql.request.selections")
+               |> Map.fetch!(@graphql_request_selections)
                |> Jason.decode!()
     end
 
@@ -49,7 +51,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       assert ["book"] =
                Queries.aliased_query()
                |> Query.query_for_attrs(variables: %{"isbn" => "A1"})
-               |> Map.fetch!("graphql.request.selections")
+               |> Map.fetch!(@graphql_request_selections)
                |> Jason.decode!()
     end
 
@@ -59,13 +61,13 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       assert ["book"] =
                Queries.batch_queries()
                |> Query.query_for_attrs(variables: %{"isbn" => "A1"}, operation_name: "OperationOne")
-               |> Map.fetch!("graphql.request.selections")
+               |> Map.fetch!(@graphql_request_selections)
                |> Jason.decode!()
 
       assert ["books"] =
                Queries.batch_queries()
                |> Query.query_for_attrs(variables: %{"isbn" => "A1"}, operation_name: "OperationTwo")
-               |> Map.fetch!("graphql.request.selections")
+               |> Map.fetch!(@graphql_request_selections)
                |> Jason.decode!()
     end
 
@@ -75,7 +77,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       result =
         Queries.query()
         |> Query.query_for_attrs(variables: %{"isbn" => "A1"})
-        |> Map.fetch!("graphql.response.result")
+        |> Map.fetch!(:"graphql.response.result")
         |> Jason.decode!()
 
       assert %{"data" => %{"book" => %{"author" => %{"age" => 18, "name" => "Ale Ali"}, "title" => "Fire"}}} = result
@@ -87,7 +89,7 @@ defmodule OpentelemetryAbsintheTest.Extraction do
       errors =
         Queries.query()
         |> Query.query_for_attrs()
-        |> Map.fetch!("graphql.response.errors")
+        |> Map.fetch!(:"graphql.response.errors")
         |> Jason.decode!()
 
       assert [

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -12,20 +12,22 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
     trace_request_selections: true
   ]
 
+  @trace_attributes [
+    :"graphql.document",
+    :"graphql.operation.name",
+    :"graphql.operation.type",
+    :"graphql.request.selections",
+    :"graphql.request.variables",
+    :"graphql.response.errors",
+    :"graphql.response.result"
+  ]
+
   describe "query" do
     test "doesn't crash when empty" do
       OpentelemetryAbsinthe.Instrumentation.setup(@capture_all)
       attrs = Query.query_for_attrs(Queries.empty_query())
 
-      assert [
-               "graphql.document",
-               "graphql.operation.name",
-               "graphql.operation.type",
-               "graphql.request.selections",
-               "graphql.request.variables",
-               "graphql.response.errors",
-               "graphql.response.result"
-             ] = attrs |> Map.keys() |> Enum.sort()
+      assert @trace_attributes = attrs |> Map.keys() |> Enum.sort()
     end
   end
 
@@ -33,14 +35,6 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
     OpentelemetryAbsinthe.Instrumentation.setup(@capture_all)
     attrs = Query.query_for_attrs(Queries.batch_queries(), variables: %{"isbn" => "A1"}, operation_name: "OperationOne")
 
-    assert [
-             "graphql.document",
-             "graphql.operation.name",
-             "graphql.operation.type",
-             "graphql.request.selections",
-             "graphql.request.variables",
-             "graphql.response.errors",
-             "graphql.response.result"
-           ] = attrs |> Map.keys() |> Enum.sort()
+    assert @trace_attributes = attrs |> Map.keys() |> Enum.sort()
   end
 end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PLATFORM-996

I think we can simply turn strings into atoms because the underlying type is binary or atom

