### PR TITLE
Set span kind to SERVER

### DIFF
--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -83,7 +83,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     save_parent_ctx()
 
     span_name = span_name(nil, nil, config.span_name)
-    new_ctx = Tracer.start_span(span_name, %{kind: :client, attributes: attributes})
+    new_ctx = Tracer.start_span(span_name, %{kind: :server, attributes: attributes})
 
     Tracer.set_current_span(new_ctx)
   end

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -83,7 +83,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     save_parent_ctx()
 
     span_name = span_name(nil, nil, config.span_name)
-    new_ctx = Tracer.start_span(span_name, %{attributes: attributes})
+    new_ctx = Tracer.start_span(span_name, %{kind: :client, attributes: attributes})
 
     Tracer.set_current_span(new_ctx)
   end

--- a/test/span_kind_test.exs
+++ b/test/span_kind_test.exs
@@ -1,0 +1,11 @@
+defmodule OpentelemetryAbsintheTest.SpanKind do
+  use OpentelemetryAbsintheTest.Case
+
+  alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
+  alias OpentelemetryAbsintheTest.Support.Query
+
+  test "span kind is client" do
+    OpentelemetryAbsinthe.Instrumentation.setup()
+    :server = Query.query_for_span_kind(Queries.invalid_query())
+  end
+end

--- a/test/span_kind_test.exs
+++ b/test/span_kind_test.exs
@@ -4,7 +4,7 @@ defmodule OpentelemetryAbsintheTest.SpanKind do
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
-  test "span kind is client" do
+  test "span kind is server" do
     OpentelemetryAbsinthe.Instrumentation.setup()
     :server = Query.query_for_span_kind(Queries.invalid_query())
   end

--- a/test/support/query.ex
+++ b/test/support/query.ex
@@ -16,7 +16,7 @@ defmodule OpentelemetryAbsintheTest.Support.Query do
     Logger.debug("Absinthe query returned: #{inspect(data)}")
 
     assert_receive {:span, span}, 5000
-    Logger.debug("Recieved span", span: span)
+    Logger.debug("Recieved span: #{inspect(span)}")
     span
   end
 

--- a/test/support/query.ex
+++ b/test/support/query.ex
@@ -9,23 +9,29 @@ defmodule OpentelemetryAbsintheTest.Support.Query do
   @fields Record.extract(:span, from: "deps/opentelemetry/include/otel_span.hrl")
   Record.defrecordp(:span, @fields)
 
-  def query_for_attrs(query, opts \\ []) do
+  def query_for_span(query, opts \\ []) do
     :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
 
     {:ok, data} = Absinthe.run(query, Schema, opts)
     Logger.debug("Absinthe query returned: #{inspect(data)}")
 
-    assert_receive {:span, span(attributes: {_, _, _, _, attributes})}, 5000
+    assert_receive {:span, span}, 5000
+    Logger.debug("Recieved span", span: span)
+    span
+  end
+
+  def query_for_attrs(query, opts \\ []) do
+    span(attributes: {_, _, _, _, attributes}) = query_for_span(query, opts)
     attributes
   end
 
   def query_for_span_name(query, opts \\ []) do
-    :otel_simple_processor.set_exporter(:otel_exporter_pid, self())
-
-    {:ok, data} = Absinthe.run(query, Schema, opts)
-    Logger.debug("Absinthe query returned: #{inspect(data)}")
-
-    assert_receive {:span, span(name: name)}, 5000
+    span(name: name) = query_for_span(query, opts)
     name
+  end
+
+  def query_for_span_kind(query, opts \\ []) do
+    span(kind: kind) = query_for_span(query, opts)
+    kind
   end
 end


### PR DESCRIPTION
Span kind: MUST always be SERVER.

Without `kind`, I couldn't get the traces in jaeger 
with latest version of Opentelemetry library.

After adding `kind`, I could see the  Absinthe traces.
![CleanShot 2023-06-20 at 18 34 45@2x](https://github.com/primait/opentelemetry_absinthe/assets/379460/b5a2a3ed-c907-4c63-9a69-9d3f00ba4130)

