### PR TITLE
Fix compilation warning on Elixir 1.15

### DIFF
--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -45,7 +45,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
       |> Enum.into(%{})
 
     if is_binary(config.span_name) do
-      Logger.warn("The opentelemetry_absinthe span_name option is deprecated and will be removed in the future")
+      Logger.warning("The opentelemetry_absinthe span_name option is deprecated and will be removed in the future")
     end
 
     :telemetry.attach(


### PR DESCRIPTION
Remove the `Logger.warn/2` in favor of `Logger.warning/2`