### PR TITLE
[COOP-566]: Add Measurement System for SLIs on Stonehenge Mutations/Queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2024-01-12
+
+### Changed
+
+- dispatch telemetry events for the handling of graphql requests
+
 ## [2.0.1] - 2023-03-14
 
 ### Changed

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -20,6 +20,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   @type graphql_handled_event_metadata :: %{
           operation_name: String.t() | nil,
           operation_type: :query | :mutation,
+          schema: Absinthe.Schema.t(),
           status: :ok | :error
         }
 
@@ -129,6 +130,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
       %{
         operation_name: operation_name,
         operation_type: operation_type,
+        schema: data.blueprint.schema,
         status: status
       }
     )

--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -76,7 +76,7 @@ defmodule OpentelemetryAbsinthe do
     OpentelemetryAbsinthe exposes `telemetry` events which can be hooked into using `:telemetry.attach/4` or `:telemetry.attach_many/4`.
     The events exposed are:
 
-    - `[:opentelemetry_absinthe, :graphql, :handled]` for when a GraphQl query has been handled, the metadata and measurements are defined in `OpentelemetryAbsinth.Instrumentation.graphql_handled_event_metadata()` and `OpentelemetryAbsinth.Instrumentation.graphql_handled_event_measurements()`
+    - `[:opentelemetry_absinthe, :graphql, :handled]` for when a GraphQl query has been handled, the metadata and measurements are defined in `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_metadata()` and `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_measurements()`
   """
 
   defdelegate setup(instrumentation_opts \\ []), to: Instrumentation

--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -70,6 +70,13 @@ defmodule OpentelemetryAbsinthe do
 
     * `trace_response_result`(default: #{Keyword.fetch!(@config, :trace_response_result)}): attaches the result returned by the server as an attribute
     * `trace_response_errors`(default: #{Keyword.fetch!(@config, :trace_response_errors)}): attaches the errors returned by the server as an attribute
+
+    ## Telemetry
+
+    OpentelemetryAbsinthe exposes `telemetry` events which can be hooked into using `:telemetry.attach/4` or `:telemetry.attach_many/4`.
+    The events exposed are:
+
+    - `[:opentelemetry_absinthe, :graphql, :handled]` for when a GraphQl query has been handled, the metadata and measurements are defined in `OpentelemetryAbsinth.Instrumentation.graphql_handled_event_metadata()` and `OpentelemetryAbsinth.Instrumentation.graphql_handled_event_measurements()`
   """
 
   defdelegate setup(instrumentation_opts \\ []), to: Instrumentation

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/opentelemetry_absinthe"
-  @version "2.0.1-rc.0"
+  @version "2.1.0"
 
   def project do
     [


### PR DESCRIPTION
This PR add the publication of telemetry events which can be used to build performace metrics for GraphQL queries that are independant of the traces.

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/COOP-566

