### PR TITLE
[COOP-566]: Add Measurement System for SLIs on Stonehenge Mutations/Queries

### DIFF
--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -71,12 +71,12 @@ defmodule OpentelemetryAbsinthe do
     * `trace_response_result`(default: #{Keyword.fetch!(@config, :trace_response_result)}): attaches the result returned by the server as an attribute
     * `trace_response_errors`(default: #{Keyword.fetch!(@config, :trace_response_errors)}): attaches the errors returned by the server as an attribute
 
-    ## Telemetry
+  ## Telemetry
 
-    OpentelemetryAbsinthe exposes `telemetry` events which can be hooked into using `:telemetry.attach/4` or `:telemetry.attach_many/4`.
-    The events exposed are:
+  OpentelemetryAbsinthe exposes `telemetry` events which can be hooked into using `:telemetry.attach/4` or `:telemetry.attach_many/4`.
+  The events exposed are:
 
-    - `[:opentelemetry_absinthe, :graphql, :handled]` for when a GraphQl query has been handled, the metadata and measurements are defined in `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_metadata()` and `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_measurements()`
+  - `[:opentelemetry_absinthe, :graphql, :handled]` for when a GraphQl query has been handled, the metadata and measurements are defined in `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_metadata()` and `OpentelemetryAbsinthe.Instrumentation.graphql_handled_event_measurements()`
   """
 
   defdelegate setup(instrumentation_opts \\ []), to: Instrumentation


### PR DESCRIPTION
Following the previous release, there was a slight issue with the indentation in libraries docs. This fixes the issue.

![image](https://github.com/primait/opentelemetry_absinthe/assets/20024170/f2514a1a-de4d-43d3-a9c5-a6f403a9fda1)

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/COOP-566

