### PR TITLE
[COAPL-665]: Improve purchase offer SLO in Stonehenge to ignore expected error types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2024-02-21
+
+### Changed
+
+- Unpinned absinthe patch version in order to not downgrade it when this package is required
+
 ## [2.2.0] - 2024-02-20
 
 ### Changed

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/opentelemetry_absinthe"
-  @version "2.2.0"
+  @version "2.2.1"
 
   def project do
     [
@@ -41,7 +41,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
 
   defp deps do
     [
-      {:absinthe, "~> 1.7.0"},
+      {:absinthe, "~> 1.7"},
       {:jason, "~> 1.2"},
       {:opentelemetry_api, "~> 1.1"},
       {:telemetry, "~> 0.4 or ~> 1.0"}


### PR DESCRIPTION
Unpinned the patch version for absinthe as this cause a downgrade when this package is required.

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/COAPL-665

