### PR TITLE
Support Metadata Plugins

### DIFF
--- a/lib/metadata_plugin.ex
+++ b/lib/metadata_plugin.ex
@@ -1,0 +1,23 @@
+defmodule OpenTelemetryAbsinthe.MetadataPlugin do
+  @moduledoc """
+    A MetadataPlugin is used to allow library integrators to add their own
+    metadata to the broadcasted telemetry events.
+
+    Note: plugins are run after `OpenTelemetryAbsinthe.MetadataPlugin.StandardMetadata`
+    so they should avoid the keys:
+    ```
+      operation_name
+      operation_type
+      schema
+      errors
+      status
+    ```
+  """
+  alias Absinthe.Blueprint
+
+  @type metadata :: %{
+          atom() => any()
+        }
+
+  @callback metadata(Blueprint.t()) :: metadata()
+end

--- a/lib/metadata_plugin.ex
+++ b/lib/metadata_plugin.ex
@@ -3,7 +3,7 @@ defmodule OpenTelemetryAbsinthe.MetadataPlugin do
     A MetadataPlugin is used to allow library integrators to add their own
     metadata to the broadcasted telemetry events.
 
-    Note: plugins are run after `OpenTelemetryAbsinthe.MetadataPlugin.StandardMetadata`
+    Note: plugins are run after `OpenTelemetryAbsinthe.StandardMetadataPlugin`
     so they should avoid the keys:
     ```
       operation_name

--- a/lib/opentelemetry_absinthe.ex
+++ b/lib/opentelemetry_absinthe.ex
@@ -73,6 +73,7 @@ defmodule OpentelemetryAbsinthe do
     * `trace_response_result`(default: #{Keyword.fetch!(@config, :trace_response_result)}): attaches the result returned by the server as an attribute
     * `trace_response_errors`(default: #{Keyword.fetch!(@config, :trace_response_errors)}): attaches the errors returned by the server as an attribute
     * `trace_subscriptions`(default: #{Keyword.fetch!(@config, :trace_subscriptions)}): attaches to `[:absinthe, :subscription, :publish]` (`:start` and `:stop`)
+    * `metadata_plugins`(default: #{Keyword.fetch!(@config, :metadata_plugins)}): supports callbacks to integrators to add entries to the published event's metadata.
 
   ## Telemetry
 

--- a/lib/standard_metadata_plugin.ex
+++ b/lib/standard_metadata_plugin.ex
@@ -1,0 +1,48 @@
+defmodule OpenTelemetryAbsinthe.StandardMetadataPlugin do
+  @moduledoc """
+    An implementation of `OpenTelemetryAbsinthe.MetadataPlugin` behaviour that
+    returns standard metadata:
+    ```
+      operation_name
+      operation_type
+      schema
+      errors
+      status
+    ```
+
+  """
+  @behaviour OpenTelemetryAbsinthe.MetadataPlugin
+
+  alias Absinthe.Blueprint
+
+  @impl OpenTelemetryAbsinthe.MetadataPlugin
+  def metadata(%Blueprint{} = blueprint) do
+    operation_type = get_operation_type(blueprint)
+    operation_name = get_operation_name(blueprint)
+
+    errors = blueprint.result[:errors]
+    status = status(errors)
+
+    %{
+      operation_name: operation_name,
+      operation_type: operation_type,
+      schema: blueprint.schema,
+      errors: errors,
+      status: status
+    }
+  end
+
+  defp status(nil), do: :ok
+  defp status([]), do: :ok
+  defp status(_error), do: :error
+
+  @spec get_operation_type(Absinthe.Blueprint.t()) :: any()
+  def get_operation_type(%Blueprint{} = blueprint) do
+    blueprint |> Absinthe.Blueprint.current_operation() |> Kernel.||(%{}) |> Map.get(:type)
+  end
+
+  @spec get_operation_name(Absinthe.Blueprint.t()) :: any()
+  def get_operation_name(%Blueprint{} = blueprint) do
+    blueprint |> Absinthe.Blueprint.current_operation() |> Kernel.||(%{}) |> Map.get(:name)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/opentelemetry_absinthe"
-  @version "2.3.0-rc.0"
+  @version "2.3.1"
 
   def project do
     [

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -115,6 +115,7 @@ defmodule OpentelemetryAbsintheTest.InstrumentationTest.TestMetadataPlugin do
 
   alias Absinthe.Blueprint
 
+  @impl OpenTelemetryAbsinthe.MetadataPlugin
   def metadata(%Blueprint{} = blueprint) do
     %{
       plugin_name: __MODULE__,

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -1,6 +1,7 @@
-defmodule OpentelemetryAbsintheTest.Instrumentation do
+defmodule OpentelemetryAbsintheTest.InstrumentationTest do
   use OpentelemetryAbsintheTest.Case
 
+  alias OpentelemetryAbsinthe.Instrumentation
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
@@ -35,5 +36,89 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
     attrs = Query.query_for_attrs(Queries.batch_queries(), variables: %{"isbn" => "A1"}, operation_name: "OperationOne")
 
     assert @trace_attributes = attrs |> Map.keys() |> Enum.sort()
+  end
+
+  describe "metadata plugins" do
+    setup do
+      config =
+        Instrumentation.default_config()
+        |> Keyword.put(:type, :operation)
+        |> Enum.into(%{})
+
+      %{config: config}
+    end
+
+    test "standard values are returned when no plugins specified", ctx do
+      assert :ok =
+               :telemetry.attach(
+                 ctx.test,
+                 [:opentelemetry_absinthe, :graphql, :handled],
+                 fn _telemetry_event, _measurements, metadata, _config ->
+                   send(self(), metadata)
+                 end,
+                 nil
+               )
+
+      assert :ok =
+               Instrumentation.handle_stop(
+                 "Test",
+                 %{},
+                 %{blueprint: BlueprintArchitect.blueprint(schema: __MODULE__)},
+                 ctx.config
+               )
+
+      assert_receive %{
+                       operation_name: "TestOperation",
+                       operation_type: :query,
+                       schema: __MODULE__,
+                       errors: nil,
+                       status: :ok
+                     },
+                     10
+    end
+
+    test "standard values are returned alongside those from plugins", ctx do
+      assert :ok =
+               :telemetry.attach(
+                 ctx.test,
+                 [:opentelemetry_absinthe, :graphql, :handled],
+                 fn _telemetry_event, _measurements, metadata, _config ->
+                   send(self(), metadata)
+                 end,
+                 nil
+               )
+
+      assert :ok =
+               Instrumentation.handle_stop(
+                 "Test",
+                 %{},
+                 %{blueprint: BlueprintArchitect.blueprint(schema: __MODULE__, source: "TestSource")},
+                 Map.put(ctx.config, :metadata_plugins, [__MODULE__.TestMetadataPlugin])
+               )
+
+      assert_receive %{
+                       operation_name: "TestOperation",
+                       operation_type: :query,
+                       schema: __MODULE__,
+                       errors: nil,
+                       status: :ok,
+                       plugin_name: __MODULE__.TestMetadataPlugin,
+                       source: "TestSource"
+                     },
+                     10
+    end
+  end
+end
+
+defmodule OpentelemetryAbsintheTest.InstrumentationTest.TestMetadataPlugin do
+  @behaviour OpenTelemetryAbsinthe.MetadataPlugin
+
+  alias Absinthe.Blueprint
+
+  def metadata(%Blueprint{} = blueprint) do
+    %{
+      plugin_name: __MODULE__,
+      source: blueprint.source
+    }
   end
 end

--- a/test/standard_metadata_plugin_test.exs
+++ b/test/standard_metadata_plugin_test.exs
@@ -1,0 +1,76 @@
+defmodule OpenTelemetryAbsinthe.StandardMetadataPluginTest do
+  use ExUnit.Case
+
+  alias OpenTelemetryAbsinthe.StandardMetadataPlugin
+
+  test "should include operation name" do
+    assert %{operation_name: "FindByUUID"} =
+             [operations: [BlueprintArchitect.operation(name: "FindByUUID")]]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include operation type" do
+    assert %{operation_type: :mutation} =
+             [operations: [BlueprintArchitect.operation(type: :mutation)]]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include schema" do
+    assert %{schema: __MODULE__} =
+             [schema: __MODULE__]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include nil errors" do
+    assert %{errors: nil} =
+             [result: %{}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+
+    assert %{errors: nil} =
+             [result: %{errors: nil}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include empty errors" do
+    assert %{errors: []} =
+             [result: %{errors: []}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include errors" do
+    assert %{errors: [:stuff_went_wrong, :wrong_number]} =
+             [result: %{errors: [:stuff_went_wrong, :wrong_number]}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include ok status" do
+    assert %{status: :ok} =
+             [result: %{}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+
+    assert %{status: :ok} =
+             [result: %{errors: nil}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+
+    assert %{status: :ok} =
+             [result: %{errors: []}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+
+  test "should include error status when there are errors" do
+    assert %{status: :error} =
+             [result: %{errors: [:stuff_went_wrong, :wrong_number]}]
+             |> BlueprintArchitect.blueprint()
+             |> StandardMetadataPlugin.metadata()
+  end
+end

--- a/test/support/blueprint_architect.ex
+++ b/test/support/blueprint_architect.ex
@@ -1,0 +1,25 @@
+defmodule BlueprintArchitect do
+  @moduledoc false
+
+  alias Absinthe.Blueprint
+
+  @spec blueprint(keyword()) :: Blueprint.t()
+  def blueprint(overrides \\ []) do
+    %{
+      operations: [operation()]
+    }
+    |> Map.merge(Enum.into(overrides, %{}))
+    |> then(&struct!(Blueprint, &1))
+  end
+
+  @spec operation(keyword()) :: Blueprint.Document.Operation.t()
+  def operation(overrides \\ []) do
+    %{
+      name: "TestOperation",
+      type: :query,
+      current: true
+    }
+    |> Map.merge(Enum.into(overrides, %{}))
+    |> then(&struct!(Blueprint.Document.Operation, &1))
+  end
+end


### PR DESCRIPTION
This PR introduces a plugin mechanism to allow integrators to specify / create their our metadata.

The plugins are passed as a setup option (metadata_plugins) and get a callback with the Absinthe.Blueprint to extract any information they need

