### PR TITLE
Support custom metadata tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Support custom metadata from integrators. Use `OpenTelemetryAbsinthe.TelemetryMetadata` to add metadata to your context which will then be broadcast.
+- Support custom metadata from integrators. Use `OpentelemetryAbsinthe.TelemetryMetadata` to add metadata to your context which will then be broadcast.
 
 ## [2.3.0-rc.0] - 2024-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [2.3.1] - 2024-05-24
+
+### Added
+
+- Support custom metadata from integrators. Use `OpenTelemetryAbsinthe.TelemetryMetadata` to add metadata to your context which will then be broadcast.
+
 ## [2.3.0-rc.0] - 2024-04-18
 
 ### Added

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -9,7 +9,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   code, it just won't do anything.)
   """
   alias Absinthe.Blueprint
-  alias OpenTelemetryAbsinthe.TelemetryMetadata
+  alias OpentelemetryAbsinthe.TelemetryMetadata
 
   require OpenTelemetry.Tracer, as: Tracer
   require OpenTelemetry.SemanticConventions.Trace, as: Conventions
@@ -17,11 +17,12 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   require Record
 
   @type graphql_handled_event_metadata :: %{
-          operation_name: String.t() | nil,
-          operation_type: :query | :mutation,
-          schema: Absinthe.Schema.t(),
-          errors: [graphql_handled_event_error()] | nil,
-          status: :ok | :error
+          required(:operation_name) => String.t() | nil,
+          required(:operation_type) => :query | :mutation,
+          required(:schema) => Absinthe.Schema.t(),
+          required(:errors) => [graphql_handled_event_error()] | nil,
+          required(:status) => :ok | :error,
+          optional(atom()) => any()
         }
 
   @type graphql_handled_event_error :: %{
@@ -162,7 +163,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
           errors: errors,
           status: status
         },
-        TelemetryMetadata.get_telemetry_metadata(data.blueprint.execution.context)
+        TelemetryMetadata.from_context(data.blueprint.execution.context)
       )
     )
 

--- a/lib/instrumentation.ex
+++ b/lib/instrumentation.ex
@@ -9,6 +9,7 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
   code, it just won't do anything.)
   """
   alias Absinthe.Blueprint
+  alias OpenTelemetryAbsinthe.TelemetryMetadata
 
   require OpenTelemetry.Tracer, as: Tracer
   require OpenTelemetry.SemanticConventions.Trace, as: Conventions
@@ -153,13 +154,16 @@ defmodule OpentelemetryAbsinthe.Instrumentation do
     telemetry_provider().execute(
       [:opentelemetry_absinthe, :graphql, :handled],
       measurements,
-      %{
-        operation_name: operation_name,
-        operation_type: operation_type,
-        schema: data.blueprint.schema,
-        errors: errors,
-        status: status
-      }
+      Map.merge(
+        %{
+          operation_name: operation_name,
+          operation_type: operation_type,
+          schema: data.blueprint.schema,
+          errors: errors,
+          status: status
+        },
+        TelemetryMetadata.get_telemetry_metadata(data.blueprint.execution.context)
+      )
     )
 
     Tracer.end_span()

--- a/lib/telemetry_metadata.ex
+++ b/lib/telemetry_metadata.ex
@@ -1,4 +1,4 @@
-defmodule OpenTelemetryAbsinthe.TelemetryMetadata do
+defmodule OpentelemetryAbsinthe.TelemetryMetadata do
   @moduledoc """
     A helper module to allow integrators to add custom data to their context
     which will then be added to the [:opentelemetry_absinthe, :graphql, :handled]
@@ -11,10 +11,10 @@ defmodule OpenTelemetryAbsinthe.TelemetryMetadata do
           optional(atom()) => any()
         }
 
-  @spec put_telemetry_metadata(absinthe_context(), telemetry_metadata()) :: absinthe_context()
-  def put_telemetry_metadata(%{} = context, %{} = metadata),
+  @spec update_context(absinthe_context(), telemetry_metadata()) :: absinthe_context()
+  def update_context(%{} = context, %{} = metadata),
     do: Map.update(context, @key, metadata, &Map.merge(&1, metadata))
 
-  @spec get_telemetry_metadata(absinthe_context()) :: telemetry_metadata()
-  def get_telemetry_metadata(%{} = context), do: Map.get(context, @key, %{})
+  @spec from_context(absinthe_context()) :: telemetry_metadata()
+  def from_context(%{} = context), do: Map.get(context, @key, %{})
 end

--- a/lib/telemetry_metadata.ex
+++ b/lib/telemetry_metadata.ex
@@ -1,0 +1,20 @@
+defmodule OpenTelemetryAbsinthe.TelemetryMetadata do
+  @moduledoc """
+    A helper module to allow integrators to add custom data to their context
+    which will then be added to the [:opentelemetry_absinthe, :graphql, :handled]
+    event
+  """
+  @key __MODULE__
+
+  @type absinthe_context :: map()
+  @type telemetry_metadata :: %{
+          optional(atom()) => any()
+        }
+
+  @spec put_telemetry_metadata(absinthe_context(), telemetry_metadata()) :: absinthe_context()
+  def put_telemetry_metadata(%{} = context, %{} = metadata),
+    do: Map.update(context, @key, metadata, &Map.merge(&1, metadata))
+
+  @spec get_telemetry_metadata(absinthe_context()) :: telemetry_metadata()
+  def get_telemetry_metadata(%{} = context), do: Map.get(context, @key, %{})
+end

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule OpentelemetryAbsinthe.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/primait/opentelemetry_absinthe"
-  @version "2.3.0-rc.0"
+  @version "2.3.1"
 
   def project do
     [

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -1,6 +1,8 @@
-defmodule OpentelemetryAbsintheTest.Instrumentation do
+defmodule OpentelemetryAbsintheTest.InstrumentationTest do
   use OpentelemetryAbsintheTest.Case
 
+  alias OpentelemetryAbsinthe.Instrumentation
+  alias OpenTelemetryAbsinthe.TelemetryMetadata
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
@@ -35,5 +37,75 @@ defmodule OpentelemetryAbsintheTest.Instrumentation do
     attrs = Query.query_for_attrs(Queries.batch_queries(), variables: %{"isbn" => "A1"}, operation_name: "OperationOne")
 
     assert @trace_attributes = attrs |> Map.keys() |> Enum.sort()
+  end
+
+  describe "handles metadata" do
+    setup do
+      config =
+        Instrumentation.default_config()
+        |> Keyword.put(:type, :operation)
+        |> Enum.into(%{})
+
+      %{config: config}
+    end
+
+    test "standard values are returned when no metadata in context", ctx do
+      assert :ok =
+               :telemetry.attach(
+                 ctx.test,
+                 [:opentelemetry_absinthe, :graphql, :handled],
+                 fn _telemetry_event, _measurements, metadata, _config ->
+                   send(self(), metadata)
+                 end,
+                 nil
+               )
+
+      assert :ok =
+               Instrumentation.handle_stop(
+                 "Test",
+                 %{},
+                 %{blueprint: BlueprintArchitect.blueprint(schema: __MODULE__)},
+                 ctx.config
+               )
+
+      assert_receive %{
+                       operation_name: "TestOperation",
+                       operation_type: :query,
+                       schema: __MODULE__,
+                       errors: nil,
+                       status: :ok
+                     },
+                     10
+    end
+
+    test "standard values are returned alongside the metadata from context", ctx do
+      context = TelemetryMetadata.put_telemetry_metadata(%{}, %{source: "TestSource", user_agent: "Insomnia"})
+
+      blueprint =
+        BlueprintArchitect.blueprint(schema: __MODULE__, execution: BlueprintArchitect.execution(context: context))
+
+      assert :ok =
+               :telemetry.attach(
+                 ctx.test,
+                 [:opentelemetry_absinthe, :graphql, :handled],
+                 fn _telemetry_event, _measurements, metadata, _config ->
+                   send(self(), metadata)
+                 end,
+                 nil
+               )
+
+      assert :ok = Instrumentation.handle_stop("Test", %{}, %{blueprint: blueprint}, ctx.config)
+
+      assert_receive %{
+                       operation_name: "TestOperation",
+                       operation_type: :query,
+                       schema: __MODULE__,
+                       errors: nil,
+                       status: :ok,
+                       user_agent: "Insomnia",
+                       source: "TestSource"
+                     },
+                     10
+    end
   end
 end

--- a/test/instrumentation_test.exs
+++ b/test/instrumentation_test.exs
@@ -2,7 +2,7 @@ defmodule OpentelemetryAbsintheTest.InstrumentationTest do
   use OpentelemetryAbsintheTest.Case
 
   alias OpentelemetryAbsinthe.Instrumentation
-  alias OpenTelemetryAbsinthe.TelemetryMetadata
+  alias OpentelemetryAbsinthe.TelemetryMetadata
   alias OpentelemetryAbsintheTest.Support.GraphQL.Queries
   alias OpentelemetryAbsintheTest.Support.Query
 
@@ -79,7 +79,7 @@ defmodule OpentelemetryAbsintheTest.InstrumentationTest do
     end
 
     test "standard values are returned alongside the metadata from context", ctx do
-      context = TelemetryMetadata.put_telemetry_metadata(%{}, %{source: "TestSource", user_agent: "Insomnia"})
+      context = TelemetryMetadata.update_context(%{}, %{source: "TestSource", user_agent: "Insomnia"})
 
       blueprint =
         BlueprintArchitect.blueprint(schema: __MODULE__, execution: BlueprintArchitect.execution(context: context))

--- a/test/support/blueprint_architect.ex
+++ b/test/support/blueprint_architect.ex
@@ -1,0 +1,32 @@
+defmodule BlueprintArchitect do
+  @moduledoc false
+
+  alias Absinthe.Blueprint
+
+  @spec blueprint(keyword()) :: Blueprint.t()
+  def blueprint(overrides \\ []) do
+    %{
+      operations: [operation()]
+    }
+    |> Map.merge(Enum.into(overrides, %{}))
+    |> then(&struct!(Blueprint, &1))
+  end
+
+  @spec operation(keyword()) :: Blueprint.Document.Operation.t()
+  def operation(overrides \\ []) do
+    %{
+      name: "TestOperation",
+      type: :query,
+      current: true
+    }
+    |> Map.merge(Enum.into(overrides, %{}))
+    |> then(&struct!(Blueprint.Document.Operation, &1))
+  end
+
+  @spec execution(keyword()) :: Blueprint.Execution.t()
+  def execution(overrides \\ []) do
+    %{}
+    |> Map.merge(Enum.into(overrides, %{}))
+    |> then(&struct!(Blueprint.Execution, &1))
+  end
+end

--- a/test/telemetry_metadata_test.exs
+++ b/test/telemetry_metadata_test.exs
@@ -1,0 +1,20 @@
+defmodule OpenTelemetryAbsinthe.TelemetryMetadataTest do
+  use ExUnit.Case
+
+  alias OpenTelemetryAbsinthe.TelemetryMetadata
+
+  test "should return an empty metadata when context is empty" do
+    assert %{} == TelemetryMetadata.get_telemetry_metadata(%{})
+  end
+
+  test "should return an empty metadata when context does not contain metadata" do
+    assert %{} == TelemetryMetadata.get_telemetry_metadata(%{foo: :bar})
+  end
+
+  test "should return same metadata that was stored" do
+    assert %{user_agent: :test} ==
+             %{}
+             |> TelemetryMetadata.put_telemetry_metadata(%{user_agent: :test})
+             |> TelemetryMetadata.get_telemetry_metadata()
+  end
+end

--- a/test/telemetry_metadata_test.exs
+++ b/test/telemetry_metadata_test.exs
@@ -1,20 +1,20 @@
-defmodule OpenTelemetryAbsinthe.TelemetryMetadataTest do
+defmodule OpentelemetryAbsinthe.TelemetryMetadataTest do
   use ExUnit.Case
 
-  alias OpenTelemetryAbsinthe.TelemetryMetadata
+  alias OpentelemetryAbsinthe.TelemetryMetadata
 
   test "should return an empty metadata when context is empty" do
-    assert %{} == TelemetryMetadata.get_telemetry_metadata(%{})
+    assert %{} == TelemetryMetadata.from_context(%{})
   end
 
   test "should return an empty metadata when context does not contain metadata" do
-    assert %{} == TelemetryMetadata.get_telemetry_metadata(%{foo: :bar})
+    assert %{} == TelemetryMetadata.from_context(%{foo: :bar})
   end
 
   test "should return same metadata that was stored" do
     assert %{user_agent: :test} ==
              %{}
-             |> TelemetryMetadata.put_telemetry_metadata(%{user_agent: :test})
-             |> TelemetryMetadata.get_telemetry_metadata()
+             |> TelemetryMetadata.update_context(%{user_agent: :test})
+             |> TelemetryMetadata.from_context()
   end
 end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/COAPL-946

This PR allows integrators to add custom metadata to their context which will be added to a broadcasted event's metadata.
